### PR TITLE
Update by Apr.23rd, 2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ Also note that, you have to create certain directories required by the batch com
 You may download the WDK 7.1.0 from Microsoft: https://www.microsoft.com/en-us/download/details.aspx?id=11800 <br>
 Presets for Free/Release build are available. Please note that the compiled binary under Free build does not come along with a digital signature. You might have to sign it yourself.
 
-## EFI Runtime Driver
-To build a EFI Runtime Driver, you should install LLVM and TianoCore EDK II. To install TianoCore EDK II, you may download latest release source code and extract to path "C:\UefiDKII". <br>
+## EFI Application and Runtime Driver
+Due to different EFI firmware implementation, most modern computer firmware does not support booting an EFI Runtime Driver directly. Therefore, it is necessary to build a separate EFI Application. In this way, modern computer firmware will boot, and the application can load runtime driver into memory. <br>
+To build a EFI Runtime Driver and Application, you should install LLVM and TianoCore EDK II. To install TianoCore EDK II, you may download latest release source code and extract to path "C:\UefiDKII". <br>
 You may download LLVM from GitHub: https://github.com/llvm/llvm-project/releases <br>
 You may download EDK II from GitHub: https://github.com/tianocore/edk2/releases <br>
 
@@ -48,9 +49,12 @@ There is a .NET Framework 4.0 based GUI loader available on GitHub now: https://
 If you are using operating systems older than Windows 8, you are supposed to manually install .NET Framework 4.0 or higher. <br>
 If you use the digital signature provided in NoirVisor's repository, then you should enable the test-signing on your machine.
 
-## EFI Runtime Driver
-Use a USB flash stick and setup with GUID Partition Table (GPT). Construct a partition and format it info FAT32 file system. After you build the image, you should copy it to \EFI\BOOT\bootx64.efi. <br>
-As the USB flash stick is ready, enter your firmware settings and set it prior to the operating system.
+## EFI Application and Runtime Driver
+Use a USB flash stick and setup with GUID Partition Table (GPT). Construct a partition and format it info FAT32 file system. After you build the image, you should see two images: bootx64.efi and NoirVisor.efi <br> 
+Those two files are EFI Application and Runtime Driver respectively. <br>
+Copy EFI Application to \EFI\BOOT\bootx64.efi <br>
+Copy EFI Runtime Driver to \NoirVisor.efi <br>
+As the USB flash stick is ready, enter your firmware settings and set it prior to the operating system. Disable Secure Boot feature unless you can sign the executable.
 
 # Detection of NoirVisor
 As specified in AMD64 Architecture Programming Manual, CPUID.EAX=1.ECX[bit 31] indicates hypervisor presence. So NoirVisor will set this bit. For CPUID instruction, since AMD defines that function leaves 0x40000000-0x400000FF are reserved for hypervisor use, we will use them. Most hypervisors defines leaf 0x40000000 is used to identify hypervisor vendor. The string constructed by register sequence EBX-ECX-EDX is used to identify vendor of hypervisor. For example, VMware hypervisor vendor string is "VMwareVMware". In NoirVisor, hypervisor vendor string is defined as "NoirVisor ZT".

--- a/build/compchk_uefix64.bat
+++ b/build/compchk_uefix64.bat
@@ -9,37 +9,47 @@ echo Platform: Unified Extensible Firmware Interface
 echo Preset: Debug/Checked Build
 echo Powered by zero.tangptr@gmail.com
 echo Copyright (c) 2018-2020, zero.tangptr@gmail.com. All Rights Reserved.
+clang-cl --version
+lld-link --version
 pause
 
 echo ============Start Compiling============
-echo Compiling UEFI Application Framework
-clang-cl ..\src\booting\efiapp\efimain.c /I"%edkpath%\MdePkg\Include" /I"%edkpath%\MdePkg\Include\X64" /I"%edkpath%\MdePkg\Include\Protocol" /I"..\src\include" /Zi /nologo /W3 /WX /Od /Oy- /D"_efi_boot" /Fa"%objpath%\efimain.cod" /Fo"%objpath%\efimain.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types
+echo Compiling UEFI Booting Facility...
+clang-cl ..\src\booting\efiapp\efimain.c /I"%edkpath%\MdePkg\Include" /I"%edkpath%\MdePkg\Include\X64" /Zi /W3 /WX /Od /Oy- /D"_efi_boot" /Fa"%objpath%\efimain.cod" /Fo"%objpath%\efimain.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types
+
+clang-cl ..\src\booting\efiapp\driver.c /I"%edkpath%\MdePkg\Include" /I"%edkpath%\MdePkg\Include\X64" /Zi /W3 /WX /Od /Oy- /D"_efi_boot" /Fa"%objpath%\efimain.cod" /Fo"%objpath%\driver.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types
+
+clang-cl ..\src\booting\efiapp\init.c /I"%edkpath%\MdePkg\Include" /I"%edkpath%\MdePkg\Include\X64" /Zi /W3 /WX /Od /Oy- /D"_efi_init" /Fa"%objpath%\init.cod" /Fo"%objpath%\init.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types
 
 echo Compiling Core Engine of Intel VT-x...
-clang-cl ..\src\vt_core\vt_main.c /I"..\src\include" /Zi /nologo /W3 /WX /Od /D"_llvm" /D"_amd64" /D"_vt_core" /D"_vt_drv" /Fa"%objpath%\vt_main.cod" /Fo"%objpath%\vt_main.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types
+clang-cl ..\src\vt_core\vt_main.c /I"..\src\include" /Zi /W3 /WX /Od /D"_llvm" /D"_amd64" /D"_vt_core" /D"_vt_drv" /Fa"%objpath%\vt_main.cod" /Fo"%objpath%\vt_main.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types
 
-clang-cl ..\src\vt_core\vt_exit.c /I"..\src\include" /Zi /nologo /W3 /WX /Od /D"_llvm" /D"_amd64" /D"_vt_core" /D"_vt_exit" /Fa"%objpath%\vt_exit.cod" /Fo"%objpath%\vt_exit.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types
+clang-cl ..\src\vt_core\vt_exit.c /I"..\src\include" /Zi /W3 /WX /Od /D"_llvm" /D"_amd64" /D"_vt_core" /D"_vt_exit" /Fa"%objpath%\vt_exit.cod" /Fo"%objpath%\vt_exit.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types
 
-clang-cl ..\src\vt_core\vt_ept.c /I"..\src\include" /Zi /nologo /W3 /WX /Od /D"_llvm" /D"_amd64" /D"_vt_core" /D"_vt_ept" /Fa"%objpath%\vt_ept.cod" /Fo"%objpath%\vt_ept.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types
+clang-cl ..\src\vt_core\vt_ept.c /I"..\src\include" /Zi  /W3 /WX /Od /D"_llvm" /D"_amd64" /D"_vt_core" /D"_vt_ept" /Fa"%objpath%\vt_ept.cod" /Fo"%objpath%\vt_ept.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types
 
-clang-cl ..\src\vt_core\vt_nvcpu.c /I"..\src\include" /Zi /nologo /W3 /WX /Od /D"_llvm" /D"_amd64" /D"_vt_core" /D"_vt_nvcpu" /Fa"%objpath%\vt_nvcpu.cod" /Fo"%objpath%\vt_nvcpu.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types
+clang-cl ..\src\vt_core\vt_nvcpu.c /I"..\src\include" /Zi  /W3 /WX /Od /D"_llvm" /D"_amd64" /D"_vt_core" /D"_vt_nvcpu" /Fa"%objpath%\vt_nvcpu.cod" /Fo"%objpath%\vt_nvcpu.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types
 
 echo Compiling Core Engine of AMD-V...
-clang-cl ..\src\svm_core\svm_main.c /I"..\src\include" /Zi /nologo /W3 /WX /Od /D"_llvm" /D"_amd64" /D"_svm_core" /D"_svm_drv" /Fa"%objpath%\svm_main.cod" /Fo"%objpath%\svm_main.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types
+clang-cl ..\src\svm_core\svm_main.c /I"..\src\include" /Zi  /W3 /WX /Od /D"_llvm" /D"_amd64" /D"_svm_core" /D"_svm_drv" /Fa"%objpath%\svm_main.cod" /Fo"%objpath%\svm_main.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types
 
-clang-cl ..\src\svm_core\svm_exit.c /I"..\src\include" /Zi /nologo /W3 /WX /Od /D"_llvm" /D"_amd64" /D"_svm_core" /D"_svm_exit" /Fa"%objpath%\svm_exit.cod" /Fo"%objpath%\svm_exit.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types
+clang-cl ..\src\svm_core\svm_exit.c /I"..\src\include" /Zi  /W3 /WX /Od /D"_llvm" /D"_amd64" /D"_svm_core" /D"_svm_exit" /Fa"%objpath%\svm_exit.cod" /Fo"%objpath%\svm_exit.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types
 
-clang-cl ..\src\svm_core\svm_npt.c /I"..\src\include" /Zi /nologo /W3 /WX /Od /D"_llvm" /D"_amd64" /D"_svm_core" /D"_svm_npt" /Fa"%objpath%\svm_npt.cod" /Fo"%objpath%\svm_npt.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types
+clang-cl ..\src\svm_core\svm_npt.c /I"..\src\include" /Zi  /W3 /WX /Od /D"_llvm" /D"_amd64" /D"_svm_core" /D"_svm_npt" /Fa"%objpath%\svm_npt.cod" /Fo"%objpath%\svm_npt.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types
 
-clang-cl ..\src\svm_core\svm_cpuid.c /I"..\src\include" /Zi /nologo /W3 /WX /Od /D"_llvm" /D"_amd64" /D"_svm_core" /D"_svm_cpuid" /Fa"%objpath%\svm_cpuid.cod" /Fo"%objpath%\svm_cpuid.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types
+clang-cl ..\src\svm_core\svm_cpuid.c /I"..\src\include" /Zi  /W3 /WX /Od /D"_llvm" /D"_amd64" /D"_svm_core" /D"_svm_cpuid" /Fa"%objpath%\svm_cpuid.cod" /Fo"%objpath%\svm_cpuid.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types
 
 echo Compiling Core of Cross-Platform Framework (XPF)...
-clang-cl ..\src\xpf_core\uefi\format.c /I"%edkpath%\MdePkg\Include" /I"%edkpath%\MdePkg\Include\X64" /I"%edkpath%\MdePkg\Include\Protocol" /I"..\src\include" /Zi /nologo /W3 /WX /Od /Oy- /D"_efi_boot" /Fa"%objpath%\format.cod" /Fo"%objpath%\format.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types -Wno-varargs
+clang-cl ..\src\xpf_core\uefi\format.c /I"%edkpath%\MdePkg\Include" /I"%edkpath%\MdePkg\Include\X64" /Zi  /W3 /WX /Od /Oy- /D"_efi_boot" /Fa"%objpath%\format.cod" /Fo"%objpath%\format.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types -Wno-varargs
 
-clang-cl ..\src\xpf_core\uefi\string.c /I"%edkpath%\MdePkg\Include" /I"%edkpath%\MdePkg\Include\X64" /I"%edkpath%\MdePkg\Include\Protocol" /I"..\src\include" /Zi /nologo /W3 /WX /Od /Oy- /D"_efi_boot" /Fa"%objpath%\string.cod" /Fo"%objpath%\string.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types
+clang-cl ..\src\xpf_core\uefi\string.c /I"%edkpath%\MdePkg\Include" /I"%edkpath%\MdePkg\Include\X64" /Zi  /W3 /WX /Od /Oy- /D"_efi_boot" /Fa"%objpath%\string.cod" /Fo"%objpath%\string.obj" /Fd"%objpath%\vc140.pdb" /GS- /Gr /TC /c /errorReport:queue -Wno-incompatible-pointer-types
 
 echo ============Start Linking============
-lld-link "%objpath%\efimain.obj" "%objpath%\format.obj" "%objpath%\string.obj" /NODEFAULTLIB /NOLOGO /OUT:"%binpath%\bootx64.efi" /SUBSYSTEM:EFI_RUNTIME_DRIVER /ENTRY:"NoirEfiEntry" /Machine:X64 /ERRORREPORT:QUEUE
+echo Linking NoirVisor EFI Loader Application...
+lld-link "%objpath%\efimain.obj" "%objpath%\init.obj" "%objpath%\format.obj" "%objpath%\string.obj" /NODEFAULTLIB  /OUT:"%binpath%\bootx64.efi" /SUBSYSTEM:EFI_APPLICATION /ENTRY:"NoirEfiEntry" /Machine:X64 /ERRORREPORT:QUEUE
+
+echo Linking NoirVisor EFI Hypervisor Runtime Driver...
+lld-link "%objpath%\driver.obj" "%objpath%\init.obj" "%objpath%\format.obj" "%objpath%\string.obj" /NODEFAULTLIB  /OUT:"%binpath%\NoirVisor.efi" /SUBSYSTEM:EFI_RUNTIME_DRIVER /ENTRY:"NoirDriverEntry" /Machine:X64 /ERRORREPORT:QUEUE
 
 echo Completed!
 pause.

--- a/src/booting/efiapp/driver.c
+++ b/src/booting/efiapp/driver.c
@@ -1,0 +1,40 @@
+/*
+  NoirVisor - Hardware-Accelerated Hypervisor solution
+
+  Copyright 2018-2020, Zero Tang. All rights reserved.
+
+  This file is the UEFI Runtime Driver Framework.
+
+  This program is distributed in the hope that it will be useful, but 
+  without any warranty (no matter implied warranty or merchantability
+  or fitness for a particular purpose, etc.).
+
+  File Location: /booting/efiapp/driver.c
+*/
+
+#include "efimain.h"
+#include "driver.h"
+
+EFI_STATUS EFIAPI NoirDriverUnload(IN EFI_HANDLE ImageHandle)
+{
+	NoirConsolePrintfW(L"NoirVisor is unloaded!\r\n");
+	return EFI_SUCCESS;
+}
+
+void EFIAPI NoirNotifyExitBootServices(IN EFI_EVENT Event,IN VOID* Context)
+{
+	;
+}
+
+EFI_STATUS EFIAPI NoirDriverEntry(IN EFI_HANDLE ImageHandle,IN EFI_SYSTEM_TABLE *SystemTable)
+{
+	NoirEfiInitialize(SystemTable);
+	NoirConsolePrintfW(L"Welcome to NoirVisor Runtime Driver!\r\n");
+	EfiBoot->CreateEvent(EVT_SIGNAL_EXIT_BOOT_SERVICES,TPL_NOTIFY,NoirNotifyExitBootServices,NULL,&NoirEfiExitBootServicesNotification);
+	EFI_GUID LoadedImageGuid=EFI_LOADED_IMAGE_PROTOCOL_GUID;
+	EFI_LOADED_IMAGE_PROTOCOL* ImageInfo;
+	EFI_STATUS st=EfiBoot->HandleProtocol(ImageHandle,&LoadedImageGuid,&ImageInfo);
+	if(st==EFI_SUCCESS)ImageInfo->Unload=NoirDriverUnload;
+	NoirConsolePrintfW(L"NoirVisor Runtime Driver Initialization Status: 0x%X\r\n",st);
+	return EFI_SUCCESS;
+}

--- a/src/booting/efiapp/driver.h
+++ b/src/booting/efiapp/driver.h
@@ -1,0 +1,15 @@
+/*
+  NoirVisor - Hardware-Accelerated Hypervisor solution
+
+  Copyright 2018-2020, Zero Tang. All rights reserved.
+
+  This file is the UEFI Runtime Driver Framework.
+
+  This program is distributed in the hope that it will be useful, but 
+  without any warranty (no matter implied warranty or merchantability
+  or fitness for a particular purpose, etc.).
+
+  File Location: /booting/efiapp/driver.h
+*/
+
+EFI_EVENT NoirEfiExitBootServicesNotification;

--- a/src/booting/efiapp/efimain.h
+++ b/src/booting/efiapp/efimain.h
@@ -13,12 +13,27 @@
 */
 
 #include <Uefi.h>
+#include <Protocol/UnicodeCollation.h>
+#include <Protocol/LoadedImage.h>
+#include <Pi/PiDxeCis.h>
+#include <Protocol/MpService.h>
+#include <Protocol/DevicePathToText.h>
+#include <Protocol/DevicePathFromText.h>
+#include <Protocol/DevicePathUtilities.h>
+#include <Protocol/SimpleFileSystem.h>
+
+#define NoirVisorPath			L"\\NoirVisor.efi"
+#define NoirVisorPathLength		30
 
 void __cdecl NoirConsolePrintfW(CHAR16* format,...);
+EFI_STATUS EFIAPI NoirEfiInitialize(IN EFI_SYSTEM_TABLE *SystemTable);
 
-EFI_BOOT_SERVICES* EfiBoot=NULL;
-EFI_RUNTIME_SERVICES* EfiRT=NULL;
-EFI_SIMPLE_TEXT_INPUT_PROTOCOL* StdIn=NULL;
-EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL* StdOut=NULL;
-EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL* StdErr=NULL;
-EFI_UNICODE_COLLATION_PROTOCOL* UnicodeCollation=NULL;
+extern EFI_BOOT_SERVICES* EfiBoot;
+extern EFI_RUNTIME_SERVICES* EfiRT;
+extern EFI_SIMPLE_TEXT_INPUT_PROTOCOL* StdIn;
+extern EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL* StdOut;
+extern EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL* StdErr;
+extern EFI_UNICODE_COLLATION_PROTOCOL* UnicodeCollation;
+extern EFI_MP_SERVICES_PROTOCOL* MpServices;
+extern EFI_DEVICE_PATH_UTILITIES_PROTOCOL* DevPathUtil;
+extern EFI_SIMPLE_FILE_SYSTEM_PROTOCOL* SimpleFileSystem;

--- a/src/booting/efiapp/init.c
+++ b/src/booting/efiapp/init.c
@@ -1,0 +1,35 @@
+/*
+  NoirVisor - Hardware-Accelerated Hypervisor solution
+
+  Copyright 2018-2020, Zero Tang. All rights reserved.
+
+  This file is the UEFI Inititialization Facility.
+
+  This program is distributed in the hope that it will be useful, but 
+  without any warranty (no matter implied warranty or merchantability
+  or fitness for a particular purpose, etc.).
+
+  File Location: /booting/efiapp/init.c
+*/
+
+#include "init.h"
+
+EFI_STATUS EFIAPI NoirEfiInitialize(IN EFI_SYSTEM_TABLE *SystemTable)
+{
+	// Initialize Basic UEFI Utility Services.
+	EfiBoot=SystemTable->BootServices;
+	EfiRT=SystemTable->RuntimeServices;
+	StdIn=SystemTable->ConIn;
+	StdOut=SystemTable->ConOut;
+	StdErr=SystemTable->StdErr;
+	// Initialize Some Protocols
+	EFI_STATUS st=EfiBoot->LocateProtocol(&UniColGuid,NULL,&UnicodeCollation);
+	if(st!=EFI_SUCCESS)goto InitEnd;
+	st=EfiBoot->LocateProtocol(&MpServGuid,NULL,&MpServices);
+	if(st!=EFI_SUCCESS)goto InitEnd;
+	st=EfiBoot->LocateProtocol(&DevPathUtilGuid,NULL,&DevPathUtil);
+	if(st!=EFI_SUCCESS)goto InitEnd;
+	st=EfiBoot->LocateProtocol(&FileSysGuid,NULL,&SimpleFileSystem);
+InitEnd:
+	return st;
+}

--- a/src/booting/efiapp/init.h
+++ b/src/booting/efiapp/init.h
@@ -1,0 +1,40 @@
+/*
+  NoirVisor - Hardware-Accelerated Hypervisor solution
+
+  Copyright 2018-2020, Zero Tang. All rights reserved.
+
+  This file is the UEFI Inititialization Facility.
+
+  This program is distributed in the hope that it will be useful, but 
+  without any warranty (no matter implied warranty or merchantability
+  or fitness for a particular purpose, etc.).
+
+  File Location: /booting/efiapp/init.h
+*/
+
+#include <Uefi.h>
+#include <Protocol/UnicodeCollation.h>
+#include <Protocol/LoadedImage.h>
+#include <Pi/PiDxeCis.h>
+#include <Protocol/MpService.h>
+#include <Protocol/DevicePathToText.h>
+#include <Protocol/DevicePathFromText.h>
+#include <Protocol/DevicePathUtilities.h>
+#include <Protocol/SimpleFileSystem.h>
+
+// Protocol Variables
+EFI_BOOT_SERVICES* EfiBoot=NULL;
+EFI_RUNTIME_SERVICES* EfiRT=NULL;
+EFI_SIMPLE_TEXT_INPUT_PROTOCOL* StdIn=NULL;
+EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL* StdOut=NULL;
+EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL* StdErr=NULL;
+EFI_UNICODE_COLLATION_PROTOCOL* UnicodeCollation=NULL;
+EFI_MP_SERVICES_PROTOCOL* MpServices=NULL;
+EFI_DEVICE_PATH_UTILITIES_PROTOCOL* DevPathUtil=NULL;
+EFI_SIMPLE_FILE_SYSTEM_PROTOCOL* SimpleFileSystem=NULL;
+
+// Protocol GUIDs
+EFI_GUID UniColGuid=EFI_UNICODE_COLLATION_PROTOCOL2_GUID;
+EFI_GUID MpServGuid=EFI_MP_SERVICES_PROTOCOL_GUID;
+EFI_GUID DevPathUtilGuid=EFI_DEVICE_PATH_UTILITIES_PROTOCOL_GUID;
+EFI_GUID FileSysGuid=EFI_SIMPLE_FILE_SYSTEM_PROTOCOL_GUID;

--- a/src/xpf_core/uefi/format.c
+++ b/src/xpf_core/uefi/format.c
@@ -49,6 +49,16 @@ int vswnprintf(CHAR16* output,UINTN limit,CHAR16* format,va_list args)
 				{
 					break;
 				}
+				case L'p':
+				{
+					int n=va_arg(args,int);
+					CHAR16 s[16];
+					NoirIntegerToHEXW64(n,s);
+					inc=NoirStringLengthW(s);
+					NoirStringCopyNW(&buf[j],s,limit-j);
+					i++;
+					break;
+				}
 				case L's':
 				{
 					CHAR8* s=va_arg(args,CHAR8*);

--- a/src/xpf_core/uefi/memory.c
+++ b/src/xpf_core/uefi/memory.c
@@ -1,0 +1,30 @@
+/*
+  NoirVisor - Hardware-Accelerated Hypervisor solution
+
+  Copyright 2018-2020, Zero Tang. All rights reserved.
+
+  This file is the EFI Memory Management Utility
+
+  This program is distributed in the hope that it will be useful, but 
+  without any warranty (no matter implied warranty or merchantability
+  or fitness for a particular purpose, etc.).
+
+  File Location: /xpf_core/uefi/devpath.c
+*/
+
+#include <Uefi.h>
+#include "ncrt.h"
+
+// These functions are intended for NoirVisor Loader Application
+void* NoirAllocateMemory(IN UINTN Size)
+{
+	void* p=NULL;
+	EFI_STATUS st=EfiBoot->AllocatePool(EfiLoaderData,Size,&p);
+	if(st==EFI_SUCCESS)EfiBoot->SetMem(p,Size,0);
+	return p;
+}
+
+void NoirFreeMemory(IN void* Memory)
+{
+	EfiBoot->FreePool(p);
+}

--- a/src/xpf_core/uefi/ncrt.h
+++ b/src/xpf_core/uefi/ncrt.h
@@ -13,7 +13,7 @@
 */
 
 #include <Uefi.h>
-#include <UnicodeCollation.h>
+#include <Protocol/UnicodeCollation.h>
 
 void NoirConsoleOutput(IN CHAR16* String);
 

--- a/src/xpf_core/uefi/string.c
+++ b/src/xpf_core/uefi/string.c
@@ -13,7 +13,7 @@
 */
 
 #include <Uefi.h>
-#include <UnicodeCollation.h>
+#include <Protocol/UnicodeCollation.h>
 #include "ncrt.h"
 
 // Simple Console Output


### PR DESCRIPTION
Add Image-Loading functionality so that EFI Runtime Driver can be loaded on any computer EFI firmware.
Separate NoirVisor with EFI Application and Runtime Driver images.
Add an ASCII-Art banner for NoirVisor.